### PR TITLE
Fix file opening

### DIFF
--- a/Application.vala
+++ b/Application.vala
@@ -32,7 +32,7 @@ class Application: Gtk.Application {
 	}
 
 	private void add_new_tab(File? file = null) {
-		core_connection.send_new_view(file != null ? file.get_basename() : null, (result) => {
+		core_connection.send_new_view(file != null ? file.get_path() : null, (result) => {
 			string view_id = result.get_string();
 			notebook.add_edit_view(new EditView(view_id, file, core_connection));
 		});


### PR DESCRIPTION
It seems that current xi-editor expects a full path rather than just the basename.
Without this patch, the following error is printed when running xi-gtk with a file argument:

`unable to read file: buffer-id-2, error: Error { repr: Os { code: 2, message: "No such file or directory" } }`