### PR TITLE
fix key-press event handling so GTK-wide shortcuts work

### DIFF
--- a/EditView.vala
+++ b/EditView.vala
@@ -71,12 +71,7 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 		blink_time = settings.get_int("cursor-blink-time") / 2;
 		can_focus = true;
 		set_has_window(true);
-		add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
-			Gdk.EventMask.BUTTON_RELEASE_MASK |
-			Gdk.EventMask.BUTTON_MOTION_MASK |
-			Gdk.EventMask.SCROLL_MASK |
-			Gdk.EventMask.SMOOTH_SCROLL_MASK);
-
+		add_events(Gdk.EventMask.BUTTON_PRESS_MASK|Gdk.EventMask.BUTTON_RELEASE_MASK|Gdk.EventMask.BUTTON_MOTION_MASK|Gdk.EventMask.SCROLL_MASK|Gdk.EventMask.SMOOTH_SCROLL_MASK);
 		if (file != null) {
 			label = file.get_basename();
 		} else {

--- a/EditView.vala
+++ b/EditView.vala
@@ -71,7 +71,12 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 		blink_time = settings.get_int("cursor-blink-time") / 2;
 		can_focus = true;
 		set_has_window(true);
-		add_events(Gdk.EventMask.BUTTON_PRESS_MASK|Gdk.EventMask.BUTTON_RELEASE_MASK|Gdk.EventMask.BUTTON_MOTION_MASK|Gdk.EventMask.SCROLL_MASK|Gdk.EventMask.SMOOTH_SCROLL_MASK);
+		add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+			Gdk.EventMask.BUTTON_RELEASE_MASK |
+			Gdk.EventMask.BUTTON_MOTION_MASK |
+			Gdk.EventMask.SCROLL_MASK |
+			Gdk.EventMask.SMOOTH_SCROLL_MASK);
+
 		if (file != null) {
 			label = file.get_basename();
 		} else {
@@ -154,6 +159,8 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 				case Gdk.Key.Page_Down:
 					send_edit("page_down" + suffix);
 					break;
+				default:
+					return Gdk.EVENT_PROPAGATE;
 			}
 		}
 		return Gdk.EVENT_STOP;


### PR DESCRIPTION
for example, C-S-i to open the GTK+ inspector (after `gsettings set org.gtk.Settings.Debug enable-inspector-keybinding true`) does not work before this change, and works after