### PR TITLE
use GTK+ theme for rendering where relevant

### DIFF
--- a/EditView.vala
+++ b/EditView.vala
@@ -33,6 +33,10 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 	public string label { private set; get; }
 	public bool has_unsaved_changes { private set; get; }
 
+	static construct {
+		set_css_name("xieditview");
+	}
+
 	// Gtk.Scrollable implementation
 	public Gtk.Adjustment hadjustment { construct set; get; }
 	public Gtk.ScrollablePolicy hscroll_policy { set; get; }
@@ -77,6 +81,8 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 		can_focus = true;
 		set_has_window(true);
 		add_events(Gdk.EventMask.BUTTON_PRESS_MASK|Gdk.EventMask.BUTTON_RELEASE_MASK|Gdk.EventMask.BUTTON_MOTION_MASK|Gdk.EventMask.SCROLL_MASK|Gdk.EventMask.SMOOTH_SCROLL_MASK);
+		get_style_context().add_class("view");
+
 		if (file != null) {
 			label = file.get_basename();
 		} else {
@@ -117,12 +123,12 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 	}
 
 	public override bool draw(Cairo.Context cr) {
-		Gdk.cairo_set_source_rgba(cr, Utilities.convert_color(0xffffffffu));
-		cr.paint();
+		var style_ctx = get_style_context();
+		style_ctx.render_background(cr, 0, 0, get_allocated_width(), get_allocated_height());
 		for (int i = first_line; i < first_line + visible_lines; i++) {
 			var line = lines_cache.get_line(i);
 			if (line != null) {
-				line.draw(cr, padding, y_offset + (i - first_line) * line_height, get_allocated_width(), ascent, line_height, blinker.draw_cursor());
+				line.draw(cr, style_ctx, padding, y_offset + (i - first_line) * line_height, get_allocated_width(), ascent, line_height, blinker.draw_cursor());
 			}
 		}
 		return Gdk.EVENT_STOP;


### PR DESCRIPTION
First, the EditView widget needs a css name (so CSS rules of the form `xieditview { background-image: linear-gradient(45deg, yellow, blue); }` work) and the .view CSS class (so the CSS rules from existing GTK+ themes will do something sane for Xi.EditView widgets).

Then the EditView asks GTK to render a background for it according to the theme, rather than painting its own in a hard-coded color. It passes its Gtk.StyleContext down to Line.draw so Line inherits the view's visual state.

In Line, we add a special case to draw the selection using the theme color scheme. Other styles that specify foreground/background have no corresponding selectors in the GTK+ theme system, so they keep using the colors and styles from xi-core.

Because the visual appearance of selection can change without the underlying Style being updated by xi-core, Line separately tracks selected ranges and the Pango.AttrList for other styles; then it merges these into a single AttrList in draw().

The application still has the final say in all coloring decisions, as it can register a custom CSS provider with higher priority than themes, but this gives sane defaults and allows user configuration via the same interface as other GTK+ programs.