### PR TITLE
implement primary clipboard pasting using middle-click

### DIFF
--- a/src/EditView.vala
+++ b/src/EditView.vala
@@ -301,7 +301,7 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 		});
 	}
 
-	public void paste_primary() {
+	private void paste_primary() {
 		get_clipboard(Gdk.SELECTION_PRIMARY).request_text((clipboard, text) => {
 			if (text != null) {
 				core_connection.send_insert(view_id, text);

--- a/src/EditView.vala
+++ b/src/EditView.vala
@@ -212,7 +212,7 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 					core_connection.send_gesture(view_id, line, column, "toggle_sel");
 				} else {
 					core_connection.send_click(view_id, line, column, 0, 1);
-					if (event.button == 2) {
+					if (event.button == Gdk.BUTTON_MIDDLE) {
 						paste_primary();
 					}
 				}

--- a/src/EditView.vala
+++ b/src/EditView.vala
@@ -212,6 +212,9 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 					core_connection.send_gesture(view_id, line, column, "toggle_sel");
 				} else {
 					core_connection.send_click(view_id, line, column, 0, 1);
+					if (event.button == 2) {
+						paste_primary();
+					}
 				}
 				break;
 			case Gdk.EventType.2BUTTON_PRESS:
@@ -292,6 +295,14 @@ class EditView: Gtk.DrawingArea, Gtk.Scrollable {
 	[Signal(action=true)]
 	public virtual signal void paste() {
 		get_clipboard(Gdk.SELECTION_CLIPBOARD).request_text((clipboard, text) => {
+			if (text != null) {
+				core_connection.send_insert(view_id, text);
+			}
+		});
+	}
+
+	public void paste_primary() {
+		get_clipboard(Gdk.SELECTION_PRIMARY).request_text((clipboard, text) => {
 			if (text != null) {
 				core_connection.send_insert(view_id, text);
 			}


### PR DESCRIPTION
Very simple change to allow middle-click primary clipboard pasting.

I'd like to get some feedback, as adding function calls and `if`s to `button_press_event` seems a bit messy. Also it's not very future-proof, as it keeps calling `send_click`, which could have unexpected side-effects on the long run.